### PR TITLE
Fix spelling of hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fun main() {
 }
 ```
 
-The [`Utils.kt`][file:utils] file also contains the `String.md5()` method for generating MD5 has out of the given string and expects more helper functions for the sake of the [KISS principle][kiss].
+The [`Utils.kt`][file:utils] file also contains the `String.md5()` method for generating MD5 hash out of the given string and expects more helper functions for the sake of the [KISS principle][kiss].
 
 Each puzzle describes some test conditions, a small portion of the information that helps check if the produced value for the given test input is valid.
 To handle that case, you can put such an input into a separated file and perform a check against the output, like:


### PR DESCRIPTION
I think the intended word here is `hash` instead of `has`. 