### PR TITLE
Update the template-cleanup readme

### DIFF
--- a/.github/template-cleanup/README.md
+++ b/.github/template-cleanup/README.md
@@ -13,7 +13,7 @@ If you're stuck with Kotlin-specific questions or anything related to this templ
 
 [^aoc]:
     [Advent of Code][aoc] – An annual event of Christmas-oriented programming challenges started December 2015.
-    Every year since then, beginning on the first day of December, a programming puzzle is published every day for twenty-four days.
+    Every year since then, beginning on the first day of December, a programming puzzle is published every day for twenty-five days.
     You can solve the puzzle and provide an answer using the language of your choice.
 
 [aoc]: https://adventofcode.com


### PR DESCRIPTION
Fixed the number of days in the generated template to state that it happens for 25 total days (one does come out on Christmas day itself)