### PR TITLE
add println extension

### DIFF
--- a/src/Day01.kt
+++ b/src/Day01.kt
@@ -12,6 +12,6 @@ fun main() {
     check(part1(testInput) == 1)
 
     val input = readInput("Day01")
-    println(part1(input))
-    println(part2(input))
+    part1(input).println()
+    part2(input).println()
 }

--- a/src/Utils.kt
+++ b/src/Utils.kt
@@ -16,8 +16,6 @@ fun String.md5() = BigInteger(1, MessageDigest.getInstance("MD5").digest(toByteA
     .padStart(32, '0')
 
 /**
- * The easy way to print anything
+ * The cleaner shorthand for printing output.
  */
-fun Any?.println() {
-    println(this)
-}
+fun Any?.println() = println(this)

--- a/src/Utils.kt
+++ b/src/Utils.kt
@@ -14,3 +14,10 @@ fun readInput(name: String) = File("src", "$name.txt")
 fun String.md5() = BigInteger(1, MessageDigest.getInstance("MD5").digest(toByteArray()))
     .toString(16)
     .padStart(32, '0')
+
+/**
+ * The easy way to print anything
+ */
+fun Any?.println() {
+    println(this)
+}


### PR DESCRIPTION
I think this is an even better way to print stuff.

For example
```kotlin
println(part1(input))
println(part2(input))
``` 
will become 
```kotlin
part1(input).println()
part2(input).println()
```

If you guys like it then I will add other print function variants...